### PR TITLE
feat: use dependsonchange from tf k8s example

### DIFF
--- a/updatecli.d/tf-k8s.yaml
+++ b/updatecli.d/tf-k8s.yaml
@@ -45,6 +45,9 @@ targets:
         - windows_amd64
         - darwin_amd64
         - darwin_arm64
+    dependson:
+      - tf-provider-k8s
+    dependsonchange: true
 
   tf-provider-k8s:
     name: Update kubernetes provider
@@ -69,3 +72,6 @@ targets:
   #         value: '{{ requiredEnv "TMPDIR" }}'
   #       - name: HCL_ATTRIBUTE
   #         value: kubernetes
+
+# Represent the minimum version of Updatecli required to run this policy
+version: v0.68.0


### PR DESCRIPTION
# Motivation
Show the `dependsonchange`

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add depends for lock to provider
- add dependsonchange for the lock
- ensure correct version of updatecli being used for this feature
<!-- SQUASH_MERGE_END -->


## Testing

```shell
updatecli apply --config updatecli.d/tf-k8s.yaml # to update to latest
updatecli diff --config updatecli.d/tf-k8s.yaml # to check lock wasn't run
```
