### PR TITLE
feat: add dynamic registry based on tofu/terraform

### DIFF
--- a/updatecli.d/tf-env.yaml
+++ b/updatecli.d/tf-env.yaml
@@ -1,3 +1,4 @@
+# {{ $opentofu := eq (env "TF_BINARY" | default "terraform") "tofu" }}
 name: terraform-provider-env
 
 sources:
@@ -14,18 +15,28 @@ sources:
       - trimprefix: "v"
 
 targets:
-  terraform-provider-env:
-    name: Update EppO/environment
-    kind: shell
+  tf-lock-environment:
+    name: Update EppO/environment lockfile
+    kind: terraform/lock
     sourceid: terraform-provider-env
     spec:
-      shell: bash
-      command: ./scripts/updatecli-hcl.sh provider
-      environments:
-        - name: HCL_FILE_TO_EDIT
-          value: terraform/versions.tf
-        - name: PATH
-        - name: TEMP
-          value: '{{ requiredEnv "TMPDIR" }}'
-        - name: HCL_ATTRIBUTE
-          value: environment
+      file: terraform/.terraform.lock.hcl
+      provider: '{{ if $opentofu }}registry.opentofu.org/{{ end }}eppo/environment'
+      platforms:
+        - linux_amd64
+        - windows_amd64
+        - darwin_amd64
+        - darwin_arm64
+    dependson:
+      - tf-provider-environment
+    dependsonchange: true
+
+  tf-provider-environment:
+    name: Update helm provider
+    kind: terraform/provider
+    sourceid: terraform-provider-env
+    spec:
+      file: terraform/versions.tf
+      provider: environment
+
+version: v0.71.0

--- a/updatecli.d/tf-helm.yaml
+++ b/updatecli.d/tf-helm.yaml
@@ -1,3 +1,4 @@
+# {{ $opentofu := eq (env "TF_BINARY" | default "terraform") "tofu" }}
 name: terraform-provider-helm
 
 sources:
@@ -15,18 +16,28 @@ sources:
       - trimprefix: "v"
 
 targets:
-  terraform-provider-helm:
-    name: Update hashicorp/helm
-    kind: shell
+  tf-lock-helm:
+    name: Update hashicorp/helm lockfile
+    kind: terraform/lock
     sourceid: terraform-provider-helm
     spec:
-      shell: bash
-      command: ./scripts/updatecli-hcl.sh provider
-      environments:
-        - name: HCL_FILE_TO_EDIT
-          value: terraform/versions.tf
-        - name: PATH
-        - name: TEMP
-          value: '{{ requiredEnv "TMPDIR" }}'
-        - name: HCL_ATTRIBUTE
-          value: helm
+      file: terraform/.terraform.lock.hcl
+      provider: '{{ if $opentofu }}registry.opentofu.org/{{ end }}hashicorp/helm'
+      platforms:
+        - linux_amd64
+        - windows_amd64
+        - darwin_amd64
+        - darwin_arm64
+    dependson:
+      - tf-provider-helm
+    dependsonchange: true
+
+  tf-provider-helm:
+    name: Update helm provider
+    kind: terraform/provider
+    sourceid: terraform-provider-helm
+    spec:
+      file: terraform/versions.tf
+      provider: helm
+
+version: v0.71.0

--- a/updatecli.d/tf-k8s.yaml
+++ b/updatecli.d/tf-k8s.yaml
@@ -1,3 +1,4 @@
+# {{ $opentofu := eq (env "TF_BINARY" | default "terraform") "tofu" }}
 name: terraform-provider-k8s
 
 sources:
@@ -22,24 +23,14 @@ conditions:
       file: https://registry.terraform.io/v1/providers/hashicorp/kubernetes
       key: version
 
-# Experiemntal from mcwarman https://github.com/mcwarman/updatecli/tree/feature/terraform
 targets:
-  # Is desired, but might be merged into the lock configuration?
-  # tf-version-k8s:
-  #   name: Update hashicorp/kubernetes provider
-  #   kind: terraform/provider
-  #   sourceid: terraform-provider-k8s
-  #   spec:
-  #     file: terraform/versions.tf
-  #     path: kubernetes
-
   tf-lock-k8s:
     name: Update hashicorp/kubernetes lockfile
     kind: terraform/lock
     sourceid: terraform-provider-k8s
     spec:
       file: terraform/.terraform.lock.hcl
-      provider: hashicorp/kubernetes
+      provider: '{{ if $opentofu }}registry.opentofu.org/{{ end }}hashicorp/kubernetes'
       platforms:
         - linux_amd64
         - windows_amd64


### PR DESCRIPTION

<!-- SQUASH_MERGE_START -->
- Remove reference to updatecli-hcl.sh since the updatecli builtin is mature enough.
- Add a switchable environment variable TF_BINARY to switch between hashicorps/opentofu registry
<!-- SQUASH_MERGE_END -->

# Testing

```
bsh ❯ rm -rf terraform/.terraform terraform/.terraform.lock.hcl
bsh ❯ tofu -chdir=terraform init
bsh ❯ export TF_BINARY=tofu
bsh ❯ just diff
// The logging here should refer to 
2024/01/16 15:03:40 [DEBUG] providerIndex.createProviderVersion: registry.opentofu.org/hashicorp/kubernetes, 2.25.2, linux_amd64
2024/01/16 15:03:40 [DEBUG] Client.ProviderPackageMetadata: GET https://registry.opentofu.org/v1/providers/hashicorp/kubernetes/2.25.2/download/linux/amd64
```

```
bsh ❯ rm -rf terraform/.terraform terraform/.terraform.lock.hcl
bsh ❯ terraform -chdir=terraform init
bsh ❯ unset TF_BINARY
bsh ❯ just diff
// The logging here should refer to registry.terraform.io
```